### PR TITLE
Add bottom navigation tabs

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/auto/artist/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/auto/artist/App.kt
@@ -26,7 +26,7 @@ import com.auto.artist.ui.back
 import com.auto.artist.ui.imageRouteNext
 import com.auto.artist.ui.screens.ColorScreen
 import com.auto.artist.ui.screens.ConceptsScreen
-import com.auto.artist.ui.screens.HomeScreen
+import com.auto.artist.ui.screens.StartTabsScreen
 import com.auto.artist.ui.screens.ImageScreen
 import com.auto.artist.ui.screens.LoadingImageScreen
 import com.auto.artist.ui.screens.MoodScreen
@@ -57,24 +57,16 @@ fun MainNavGraph(
     ) {
         composable(Route.Start.route) {
             println("ddd -> Start route")
-            Scaffold { paddingValues ->
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                ) {
-                    HomeScreen(
-                        navController = navController,
-                        viewModel = imageViewModel,
-                        onImageClick = { imageEntity ->
-                            println("ddd -> onImageClick prompt: ${imageEntity.prompt}")
-                            imageViewModel.updateUiState(UiState.READY(imageEntity))
-                            println("UiState updated to READY with image: $imageEntity")
-                            navController.navigate(Route.Image.route)
-                        }
-                    )
+            StartTabsScreen(
+                navController = navController,
+                viewModel = imageViewModel,
+                onImageClick = { imageEntity ->
+                    println("ddd -> onImageClick prompt: ${imageEntity.prompt}")
+                    imageViewModel.updateUiState(UiState.READY(imageEntity))
+                    println("UiState updated to READY with image: $imageEntity")
+                    navController.navigate(Route.Image.route)
                 }
-            }
+            )
         }
 
         composable(Route.Color.route) {

--- a/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/HistoryScreen.kt
@@ -1,0 +1,18 @@
+package com.auto.artist.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HistoryScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("History screen coming soon")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/StartScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/StartScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -46,6 +48,7 @@ import coil3.compose.AsyncImage
 import com.auto.artist.db.ImageEntity
 import com.auto.artist.ui.ImageViewModel
 import com.auto.artist.ui.Route
+import com.auto.artist.ui.screens.HistoryScreen
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -156,6 +159,68 @@ fun showGallery(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun StartTabsScreen(
+    navController: NavController,
+    viewModel: ImageViewModel,
+    onImageClick: (ImageEntity) -> Unit,
+) {
+    var selectedTab by remember { mutableStateOf(0) }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = { CenterAlignedTopAppBar(title = { Text("Auto Artist") }) },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    icon = { Icon(Icons.Default.Favorite, contentDescription = "Gallery") },
+                    label = { Text("Gallery") }
+                )
+                NavigationBarItem(
+                    selected = selectedTab == 1,
+                    onClick = {
+                        selectedTab = 1
+                        navController.navigate(Route.Color.route)
+                    },
+                    icon = { Icon(Icons.Default.Add, contentDescription = "New Image") },
+                    label = { Text("New Image") }
+                )
+                NavigationBarItem(
+                    selected = selectedTab == 2,
+                    onClick = { selectedTab = 2 },
+                    icon = { Icon(Icons.Default.Favorite, contentDescription = "History") },
+                    label = { Text("History") }
+                )
+            }
+        }
+    ) { paddingValues ->
+        when (selectedTab) {
+            0 -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            ) {
+                HomeScreen(
+                    navController = navController,
+                    viewModel = viewModel,
+                    onImageClick = onImageClick
+                )
+            }
+
+            2 -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                HistoryScreen()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/StartScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/StartScreen.kt
@@ -70,7 +70,7 @@ fun HomeScreen(
                 }
 
                 viewModel.allImages.value?.isNotEmpty() == true -> {
-                    showGallery(
+                    Gallery(
                         navController = navController,
                         generatedImages = viewModel.allImages.value!!,
                         viewModel = viewModel,
@@ -100,7 +100,7 @@ fun HomeScreen(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun showGallery(
+fun Gallery(
     navController: NavController,
     generatedImages: List<ImageEntity>,
     viewModel: ImageViewModel,
@@ -110,17 +110,21 @@ fun showGallery(
 
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Fixed(2),
-        verticalItemSpacing = 8.dp,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxSize().padding(8.dp)
+        verticalItemSpacing = 2.dp,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        modifier = Modifier.fillMaxSize().padding(2.dp)
     ) {
         items(generatedImages.size) { index ->
             val image = generatedImages[index]
-            val aspect = if (index % 3 == 0) 1.3f else 1f
+            val aspect = if (index % 5 == 0)
+                1.4f
+            else if (index % 3 == 0)
+                1.2f
+            else 1f
 
             Card(
                 modifier = Modifier
-                    .padding(4.dp)
+                    .padding(1.dp)
                     .combinedClickable(
                         onClick = { onImageClick(image) },
                         onLongClick = { setSelectedImageId(image.id) }

--- a/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/StartScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/auto/artist/ui/screens/StartScreen.kt
@@ -168,6 +168,7 @@ fun Gallery(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StartTabsScreen(
     navController: NavController,


### PR DESCRIPTION
## Summary
- add HistoryScreen placeholder
- show a tab scaffold with gallery, new image and history tabs
- start navigation uses the new tab screen

## Testing
- `./gradlew :composeApp:tasks --all` *(fails: missing `local.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6848a18c8494832da0ec7ed50c385a24